### PR TITLE
fix alphaArray of toString method

### DIFF
--- a/src/int64-type.cc
+++ b/src/int64-type.cc
@@ -217,7 +217,7 @@ void Int64Wrapper::ToString(const FunctionCallbackInfo<Value>& args) {
     const Int64Wrapper* self = ObjectWrap::Unwrap<Int64Wrapper>(args.Holder());
     auto toChar = [](int64_t val) -> char {
         const char alphaArray[] = 
-            "0123456789acdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/";
+            "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/";
         assert(val >= 0 && (unsigned) val < sizeof(alphaArray));
         return alphaArray[val];
     };


### PR DESCRIPTION
The `alphaArray` lookup table was missing the character `b` leading to hilarious results when invoking toString().

```
> i64 = require('node-cint64').Int64
[Function: Int64]
> foo = new i64(Buffer.from([0xff, 0, 0, 0, 0, 0, 0, 0]))
Int64 {}
> foo.toString(16)
'gg'
```